### PR TITLE
TMP_Text gets automatically assigned when TextEffect Component gets added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_Store
+.vs/

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -145,6 +145,11 @@ namespace EasyTextEffects
             UpdateStyleInfos();
         }
 
+        private void Reset()
+        {
+            text = GetComponent<TMP_Text>();
+        }
+
         private void OnValidate()
         {
 #if UNITY_EDITOR

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -43,7 +43,13 @@ namespace EasyTextEffects
 
             var styles = textInfo.linkInfo;
 
-            // copy global effects
+            CopyGlobalEffects(textInfo);
+            AddTagEffects(styles);
+
+            StartOnStartEffects();
+        }
+        private void CopyGlobalEffects(TMP_TextInfo textInfo)
+        {
             onStartEffects_ = new List<GlobalTextEffectEntry>();
             manualEffects_ = new List<GlobalTextEffectEntry>();
             globalEffects.ForEach(_entry =>
@@ -60,12 +66,13 @@ namespace EasyTextEffects
                 else
                     manualEffects_.Add(effectEntry);
             });
-
-            // add effects to list
+        }
+        private void AddTagEffects(TMP_LinkInfo[] styles)
+        {
             allTagEffects_ = new List<TextEffectEntry>(tagEffects);
             if (usePreset && preset != null)
                 allTagEffects_.AddRange(preset.tagEffects);
-            
+
             onStartTagEffects_ = new List<TextEffectEntry>();
             manualTagEffects_ = new List<TextEffectEntry>();
             for (var i = 0; i < styles.Length; i++)
@@ -90,10 +97,8 @@ namespace EasyTextEffects
                         manualTagEffects_.Add(entryCopy);
                 }
             }
-
-            StartOnStartEffects();
         }
-
+       
         private List<TextEffectEntry> GetTagEffectsByName(string _effectName)
         {
             var results = new List<TextEffectEntry>();

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -52,6 +52,12 @@ namespace EasyTextEffects
         {
             onStartEffects_ = new List<GlobalTextEffectEntry>();
             manualEffects_ = new List<GlobalTextEffectEntry>();
+
+            if (globalEffects == null)
+            {
+                return;
+            }
+
             globalEffects.ForEach(_entry =>
             {
                 if (_entry.effect == null)
@@ -69,12 +75,19 @@ namespace EasyTextEffects
         }
         private void AddTagEffects(TMP_LinkInfo[] styles)
         {
+            onStartTagEffects_ = new List<TextEffectEntry>();
+            manualTagEffects_ = new List<TextEffectEntry>();
+
+            if (tagEffects == null)
+            {
+                return;
+            }
+
             allTagEffects_ = new List<TextEffectEntry>(tagEffects);
             if (usePreset && preset != null)
                 allTagEffects_.AddRange(preset.tagEffects);
 
-            onStartTagEffects_ = new List<TextEffectEntry>();
-            manualTagEffects_ = new List<TextEffectEntry>();
+            
             for (var i = 0; i < styles.Length; i++)
             {
                 TMP_LinkInfo style = styles[i];


### PR DESCRIPTION
The Reset() method fires when a component gets added to a gameObject and will fill out the TMP_Text reference when it exists.
The null checks are required because by assigning the reference OnValidate() gets called as well and those lists are not initialized yet.