### PR TITLE
Added OnEffectCompleted Event to Entry for "One Time" and "Loop Fixed Duration" Events

### DIFF
--- a/Runtime/Effects/Effect_Composite.cs
+++ b/Runtime/Effects/Effect_Composite.cs
@@ -30,16 +30,16 @@ namespace EasyTextEffects.Effects
             }
         }
 
-        public override void StartEffect()
+        public override void StartEffect(TextEffectEntry entry)
         {
-            base.StartEffect();
+            base.StartEffect(entry);
             
             foreach (TextEffectInstance effect in effects)
             {
                 if (!effect) continue;
                 effect.startCharIndex = startCharIndex;
                 effect.charLength = charLength;
-                effect.StartEffect();
+                effect.StartEffect(entry);
             }
         }
 

--- a/Runtime/Effects/Effect_PerVertex.cs
+++ b/Runtime/Effects/Effect_PerVertex.cs
@@ -51,9 +51,9 @@ namespace EasyTextEffects.Effects
             bottomRightEffects.ForEach(_effect => _effect?.ApplyEffect(_textInfo, _charIndex, 3, 3));
         }
 
-        public override void StartEffect()
+        public override void StartEffect(TextEffectEntry entry)
         {
-            base.StartEffect();
+            base.StartEffect(entry);
             var allEffects = new List<List<TextEffectInstance>> 
             {
                 topLeftEffects,
@@ -69,7 +69,7 @@ namespace EasyTextEffects.Effects
                     if (!effect) continue;
                     effect.startCharIndex = startCharIndex;
                     effect.charLength = charLength;
-                    effect.StartEffect();
+                    effect.StartEffect(entry);
                 }
             }
 

--- a/Runtime/Effects/TextEffectInstance.cs
+++ b/Runtime/Effects/TextEffectInstance.cs
@@ -1,7 +1,10 @@
 using EasyTextEffects.Editor.EditorDocumentation;
 using EasyTextEffects.Editor.MyBoxCopy.Attributes;
+
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.Serialization;
+
 using static EasyTextEffects.Editor.EditorDocumentation.FoldBoxAttribute;
 
 namespace EasyTextEffects.Effects
@@ -68,6 +71,8 @@ namespace EasyTextEffects.Effects
 
         protected float startTime;
         protected bool started;
+        protected bool isComplete;
+        private TextEffectEntry currentEntry;
 
         protected bool CheckCanApplyEffect(int _charIndex)
         {
@@ -76,8 +81,11 @@ namespace EasyTextEffects.Effects
 
         public virtual void StartEffect()
         {
+            currentEntry = entry;
+
             started = true;
             startTime = TimeUtil.GetTime();
+            isComplete = false;
 
             if (animationType == AnimationType.OneTime || animationType == AnimationType.LoopFixedDuration)
             {
@@ -99,6 +107,7 @@ namespace EasyTextEffects.Effects
         public virtual void StopEffect()
         {
             started = false;
+            isComplete = true;
         }
 
         protected float Interpolate(float _start, float _end, int _charIndex)
@@ -134,8 +143,32 @@ namespace EasyTextEffects.Effects
         private float GetTimeForChar(int _charIndex)
         {
             var time = TimeUtil.GetTime();
+
+            // Check completion for LoopFixedDuration
             if (animationType == AnimationType.LoopFixedDuration && time - startTime > fixedDuration)
+            {
                 startTime += fixedDuration;
+                if (!isComplete)
+                {
+                    isComplete = true;
+                    currentEntry?.InvokeCompleted();
+                }
+            }
+
+            // Check completion for OneTime
+            else if (animationType == AnimationType.OneTime && !isComplete)
+            {
+                float totalDuration = noDelayForChars ?
+                    durationPerChar :
+                    (durationPerChar + (timeBetweenChars * (charLength - 1)));
+
+                if (time - startTime > totalDuration)
+                {
+                    isComplete = true;
+                    currentEntry?.InvokeCompleted();
+                }
+            }
+
 
             var charOrder = _charIndex - startCharIndex;
             if (reverseCharOrder)
@@ -143,6 +176,8 @@ namespace EasyTextEffects.Effects
             var charStartTime = startTime + timeBetweenChars * charOrder;
             return time - charStartTime;
         }
+
+        public bool IsComplete() => isComplete;
 
         public virtual TextEffectInstance Instantiate()
         {

--- a/Runtime/GlobalTextEffectEntry.cs
+++ b/Runtime/GlobalTextEffectEntry.cs
@@ -1,5 +1,8 @@
 using EasyTextEffects.Effects;
 
+using UnityEngine;
+using UnityEngine.Events;
+
 namespace EasyTextEffects
 {
     [System.Serializable]
@@ -13,6 +16,19 @@ namespace EasyTextEffects
 
         public TriggerWhen triggerWhen;
         public TextEffectInstance effect;
+
+        public UnityEvent onEffectCompleted = new UnityEvent();
+
+        public void StartEffect()
+        {
+            effect.StartEffect(this);
+        }
+
+        internal void InvokeCompleted()
+        {
+            onEffectCompleted?.Invoke();
+		}
+
     }
 
     [System.Serializable]

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
+
 using EasyTextEffects.Editor.MyBoxCopy.Attributes;
 using EasyTextEffects.Editor.MyBoxCopy.Extensions;
 using EasyTextEffects.Effects;
+
 using TMPro;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -67,6 +69,7 @@ namespace EasyTextEffects
                 effectEntry.effect.startCharIndex = 0;
                 effectEntry.effect.charLength = textInfo.characterCount;
                 effectEntry.overrideTagEffects = _entry.overrideTagEffects;
+                effectEntry.onEffectCompleted = _entry.onEffectCompleted;
                 if (_entry.triggerWhen == GlobalTextEffectEntry.TriggerWhen.OnStart)
                     onStartEffects_.Add(effectEntry);
                 else
@@ -222,14 +225,14 @@ namespace EasyTextEffects
 
         public void StartOnStartEffects()
         {
-            onStartEffects_.ForEach(_entry => _entry.effect.StartEffect());
-            onStartTagEffects_.ForEach(_entry => _entry.effect.StartEffect());
+            onStartEffects_.ForEach(_entry => _entry.StartEffect());
+            onStartTagEffects_.ForEach(_entry => _entry.StartEffect());
             nextUpdateTime_ = 0; // immediately update
         }
 
         public void StartManualEffects()
         {
-            manualEffects_.ForEach(_entry => _entry.effect.StartEffect());
+            manualEffects_.ForEach(_entry => _entry.StartEffect());
         }
 
         public void StopManualEffects()
@@ -239,7 +242,7 @@ namespace EasyTextEffects
 
         public void StartManualTagEffects()
         {
-            manualTagEffects_.ForEach(_entry => _entry.effect.StartEffect());
+            manualTagEffects_.ForEach(_entry => _entry.StartEffect());
         }
 
         public void StopManualTagEffects()
@@ -254,7 +257,7 @@ namespace EasyTextEffects
             var names = manualEffects_.Select(_entry => _entry.effect.effectTag).ToList();
 
             if (effectEntry != null)
-                effectEntry.effect.StartEffect();
+                effectEntry.StartEffect();
             else
             {
                 Debug.LogWarning($"Effect {_effectName} not found");
@@ -269,7 +272,7 @@ namespace EasyTextEffects
             var names = manualTagEffects_.Select(_entry => _entry.effect.effectTag).ToList();
 
             if (effectEntry != null)
-                effectEntry.effect.StartEffect();
+                effectEntry.StartEffect();
             else
             {
                 Debug.LogWarning($"Effect {_effectName} not found");


### PR DESCRIPTION
This update introduces the OnEffectCompleted event to the Entry component. The event is triggered when the "One Time" or "Loop Fixed Duration" effects are completed. This provides developers with a convenient way to respond to the completion of these specific events.

<img width="459" alt="image" src="https://github.com/user-attachments/assets/c37b190b-b3b1-4667-89b2-a0eb7ea7ebd1" />
