### PR TITLE
Added OnEffectCompleted Event to Entry for "One Time" and "Loop Fixed Duration" Events

### DIFF
--- a/Runtime/Effects/Effect_Composite.cs
+++ b/Runtime/Effects/Effect_Composite.cs
@@ -30,16 +30,16 @@ namespace EasyTextEffects.Effects
             }
         }
 
-        public override void StartEffect()
+        public override void StartEffect(TextEffectEntry entry)
         {
-            base.StartEffect();
+            base.StartEffect(entry);
             
             foreach (TextEffectInstance effect in effects)
             {
                 if (!effect) continue;
                 effect.startCharIndex = startCharIndex;
                 effect.charLength = charLength;
-                effect.StartEffect();
+                effect.StartEffect(entry);
             }
         }
 

--- a/Runtime/Effects/Effect_PerVertex.cs
+++ b/Runtime/Effects/Effect_PerVertex.cs
@@ -51,9 +51,9 @@ namespace EasyTextEffects.Effects
             bottomRightEffects.ForEach(_effect => _effect?.ApplyEffect(_textInfo, _charIndex, 3, 3));
         }
 
-        public override void StartEffect()
+        public override void StartEffect(TextEffectEntry entry)
         {
-            base.StartEffect();
+            base.StartEffect(entry);
             var allEffects = new List<List<TextEffectInstance>> 
             {
                 topLeftEffects,
@@ -69,7 +69,7 @@ namespace EasyTextEffects.Effects
                     if (!effect) continue;
                     effect.startCharIndex = startCharIndex;
                     effect.charLength = charLength;
-                    effect.StartEffect();
+                    effect.StartEffect(entry);
                 }
             }
 

--- a/Runtime/GlobalTextEffectEntry.cs
+++ b/Runtime/GlobalTextEffectEntry.cs
@@ -1,5 +1,8 @@
 using EasyTextEffects.Effects;
 
+using UnityEngine;
+using UnityEngine.Events;
+
 namespace EasyTextEffects
 {
     [System.Serializable]
@@ -13,6 +16,18 @@ namespace EasyTextEffects
 
         public TriggerWhen triggerWhen;
         public TextEffectInstance effect;
+
+        public UnityEvent onEffectCompleted = new UnityEvent();
+
+        public void StartEffect()
+        {
+            effect.StartEffect(this);
+        }
+
+        internal void InvokeCompleted()
+        {
+            onEffectCompleted?.Invoke();
+        }
     }
 
     [System.Serializable]

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
+
 using EasyTextEffects.Editor.MyBoxCopy.Attributes;
 using EasyTextEffects.Editor.MyBoxCopy.Extensions;
 using EasyTextEffects.Effects;
+
 using TMPro;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -67,6 +69,7 @@ namespace EasyTextEffects
                 effectEntry.effect.startCharIndex = 0;
                 effectEntry.effect.charLength = textInfo.characterCount;
                 effectEntry.overrideTagEffects = _entry.overrideTagEffects;
+                effectEntry.onEffectCompleted = _entry.onEffectCompleted;
                 if (_entry.triggerWhen == GlobalTextEffectEntry.TriggerWhen.OnStart)
                     onStartEffects_.Add(effectEntry);
                 else
@@ -222,14 +225,14 @@ namespace EasyTextEffects
 
         public void StartOnStartEffects()
         {
-            onStartEffects_.ForEach(_entry => _entry.effect.StartEffect());
-            onStartTagEffects_.ForEach(_entry => _entry.effect.StartEffect());
+            onStartEffects_.ForEach(_entry => _entry.StartEffect());
+            onStartTagEffects_.ForEach(_entry => _entry.StartEffect());
             nextUpdateTime_ = 0; // immediately update
         }
 
         public void StartManualEffects()
         {
-            manualEffects_.ForEach(_entry => _entry.effect.StartEffect());
+            manualEffects_.ForEach(_entry => _entry.StartEffect());
         }
 
         public void StopManualEffects()
@@ -239,7 +242,7 @@ namespace EasyTextEffects
 
         public void StartManualTagEffects()
         {
-            manualTagEffects_.ForEach(_entry => _entry.effect.StartEffect());
+            manualTagEffects_.ForEach(_entry => _entry.StartEffect());
         }
 
         public void StopManualTagEffects()
@@ -254,7 +257,7 @@ namespace EasyTextEffects
             var names = manualEffects_.Select(_entry => _entry.effect.effectTag).ToList();
 
             if (effectEntry != null)
-                effectEntry.effect.StartEffect();
+                effectEntry.StartEffect();
             else
             {
                 Debug.LogWarning($"Effect {_effectName} not found");
@@ -269,7 +272,7 @@ namespace EasyTextEffects
             var names = manualTagEffects_.Select(_entry => _entry.effect.effectTag).ToList();
 
             if (effectEntry != null)
-                effectEntry.effect.StartEffect();
+                effectEntry.StartEffect();
             else
             {
                 Debug.LogWarning($"Effect {_effectName} not found");


### PR DESCRIPTION
This update introduces the OnEffectCompleted event to the Entry component. The event is triggered when the "One Time" or "Loop Fixed Duration" effects are completed. This provides developers with a convenient way to respond to the completion of these specific events.

<img width="456" alt="image" src="https://github.com/user-attachments/assets/13b5db01-2b03-430c-bede-b3239ff27fa1" />
