### PR TITLE
fix bug: onEffectCompleted events are not invoked for tag effects

### DIFF
--- a/Runtime/GlobalTextEffectEntry.cs
+++ b/Runtime/GlobalTextEffectEntry.cs
@@ -2,7 +2,6 @@ using EasyTextEffects.Effects;
 
 using UnityEngine;
 using UnityEngine.Events;
-using TMPro;
 
 namespace EasyTextEffects
 {
@@ -21,12 +20,12 @@ namespace EasyTextEffects
         public UnityEvent onEffectCompleted = new UnityEvent();
         
         
-        public TextEffectEntry GetCopy(TMP_LinkInfo style)
+        public TextEffectEntry GetCopy(int startCharIndex, int charLength)
         {
             var entryCopy = new TextEffectEntry();
             entryCopy.effect = effect.Instantiate();
-            entryCopy.effect.startCharIndex = style.linkTextfirstCharacterIndex;
-            entryCopy.effect.charLength = style.linkTextLength;
+            entryCopy.effect.startCharIndex = startCharIndex;
+            entryCopy.effect.charLength = charLength;
             entryCopy.triggerWhen = triggerWhen;
             entryCopy.onEffectCompleted = onEffectCompleted;
             

--- a/Runtime/GlobalTextEffectEntry.cs
+++ b/Runtime/GlobalTextEffectEntry.cs
@@ -2,6 +2,7 @@ using EasyTextEffects.Effects;
 
 using UnityEngine;
 using UnityEngine.Events;
+using TMPro;
 
 namespace EasyTextEffects
 {
@@ -18,6 +19,19 @@ namespace EasyTextEffects
         public TextEffectInstance effect;
 
         public UnityEvent onEffectCompleted = new UnityEvent();
+        
+        
+        public TextEffectEntry GetCopy(TMP_LinkInfo style)
+        {
+            var entryCopy = new TextEffectEntry();
+            entryCopy.effect = effect.Instantiate();
+            entryCopy.effect.startCharIndex = style.linkTextfirstCharacterIndex;
+            entryCopy.effect.charLength = style.linkTextLength;
+            entryCopy.triggerWhen = triggerWhen;
+            entryCopy.onEffectCompleted = onEffectCompleted;
+            
+            return entryCopy;
+        }
 
         public void StartEffect()
         {

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -105,10 +105,8 @@ namespace EasyTextEffects
                 {
                     if (entry.effect == null)
                         continue;
-                    var entryCopy = new TextEffectEntry();
-                    entryCopy.effect = entry.effect.Instantiate();
-                    entryCopy.effect.startCharIndex = style.linkTextfirstCharacterIndex;
-                    entryCopy.effect.charLength = style.linkTextLength;
+                    // note: make sure onEffectCompleted events get copied 
+                    TextEffectEntry entryCopy = entry.GetCopy(style);
                     if (entry.triggerWhen == OnStart)
                         onStartTagEffects_.Add(entryCopy);
                     else

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -106,7 +106,9 @@ namespace EasyTextEffects
                     if (entry.effect == null)
                         continue;
                     // note: make sure onEffectCompleted events get copied 
-                    TextEffectEntry entryCopy = entry.GetCopy(style);
+                    TextEffectEntry entryCopy = entry.GetCopy(
+                        style.linkTextfirstCharacterIndex,
+                        style.linkTextLength);
                     if (entry.triggerWhen == OnStart)
                         onStartTagEffects_.Add(entryCopy);
                     else


### PR DESCRIPTION
Bug: onEffectCompleted events are not invoked for tag effects. because the event field is not copied when adding tag effects to onStartTagEffects and manualTagEffects in TextEffect.AddTagEffects().

Fix: move the copy logic into TextEffectEntry.GetCopy() method, and copy both the triggerWhen and onEffectCompleted fields.