### PR TITLE
Live Reload

### DIFF
--- a/Editor/ColorEffectEditor.cs
+++ b/Editor/ColorEffectEditor.cs
@@ -10,7 +10,9 @@ namespace EasyTextEffects.Editor
         {
             var myScript = (Effect_Color)target;
             EditorGUI.BeginChangeCheck();
+            serializedObject.Update();
             DrawDefaultInspector();
+            serializedObject.ApplyModifiedProperties();
             if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
         }
     }

--- a/Editor/ColorEffectEditor.cs
+++ b/Editor/ColorEffectEditor.cs
@@ -1,0 +1,17 @@
+using EasyTextEffects.Effects;
+using UnityEditor;
+
+namespace EasyTextEffects.Editor
+{
+    [CustomEditor(typeof(Effect_Color))]
+    public class ColorEffectEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var myScript = (Effect_Color)target;
+            EditorGUI.BeginChangeCheck();
+            DrawDefaultInspector();
+            if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
+        }
+    }
+}

--- a/Editor/ColorEffectEditor.cs.meta
+++ b/Editor/ColorEffectEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b3e0a70993e340f7bb45986618d5b157
+timeCreated: 1749307271

--- a/Editor/CompositeEffectEditor.cs
+++ b/Editor/CompositeEffectEditor.cs
@@ -34,11 +34,15 @@ This can be useful if there is a common set of effects that you want to apply to
 
             EditorDocumentation.EditorDocumentation.EndFoldBox();
 
+            EditorGUI.BeginChangeCheck();
+            
             // draw the list of effects 
             serializedObject.Update();
             EditorGUILayout.PropertyField(serializedObject.FindProperty("effectTag"), true);
             EditorGUILayout.PropertyField(serializedObject.FindProperty("effects"), true);
             serializedObject.ApplyModifiedProperties();
+            
+            if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
         }
     }
 }

--- a/Editor/MoveEffectEditor.cs
+++ b/Editor/MoveEffectEditor.cs
@@ -10,7 +10,9 @@ namespace EasyTextEffects.Editor
         {
             var myScript = (Effect_Move)target;
             EditorGUI.BeginChangeCheck();
+            serializedObject.Update();
             DrawDefaultInspector();
+            serializedObject.ApplyModifiedProperties();
             if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
         }
     }

--- a/Editor/MoveEffectEditor.cs
+++ b/Editor/MoveEffectEditor.cs
@@ -1,0 +1,17 @@
+using EasyTextEffects.Effects;
+using UnityEditor;
+
+namespace EasyTextEffects.Editor
+{
+    [CustomEditor(typeof(Effect_Move))]
+    public class MoveEffectEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var myScript = (Effect_Move)target;
+            EditorGUI.BeginChangeCheck();
+            DrawDefaultInspector();
+            if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
+        }
+    }
+}

--- a/Editor/MoveEffectEditor.cs.meta
+++ b/Editor/MoveEffectEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2bc609117fff421ba64031cb5cec7da4
+timeCreated: 1749308276

--- a/Editor/PerVertexEffectEditor.cs
+++ b/Editor/PerVertexEffectEditor.cs
@@ -33,6 +33,8 @@ A simple example: you could let the top vertices move up and down while keeping 
 
             EditorDocumentation.EditorDocumentation.EndFoldBox();
 
+            EditorGUI.BeginChangeCheck();
+            
             serializedObject.Update();
             EditorGUILayout.PropertyField(serializedObject.FindProperty("effectTag"), true);
             EditorGUILayout.PropertyField(serializedObject.FindProperty("topLeftEffects"), true);
@@ -40,6 +42,8 @@ A simple example: you could let the top vertices move up and down while keeping 
             EditorGUILayout.PropertyField(serializedObject.FindProperty("bottomLeftEffects"), true);
             EditorGUILayout.PropertyField(serializedObject.FindProperty("bottomRightEffects"), true);
             serializedObject.ApplyModifiedProperties();
+
+            if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
         }
     }
 }

--- a/Editor/RotateEffectEditor.cs
+++ b/Editor/RotateEffectEditor.cs
@@ -10,7 +10,9 @@ namespace EasyTextEffects.Editor
         {
             var myScript = (Effect_Rotate)target;
             EditorGUI.BeginChangeCheck();
+            serializedObject.Update();
             DrawDefaultInspector();
+            serializedObject.ApplyModifiedProperties();
             if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
         }
     }

--- a/Editor/RotateEffectEditor.cs
+++ b/Editor/RotateEffectEditor.cs
@@ -1,0 +1,17 @@
+using EasyTextEffects.Effects;
+using UnityEditor;
+
+namespace EasyTextEffects.Editor
+{
+    [CustomEditor(typeof(Effect_Rotate))]
+    public class RotateEffectEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var myScript = (Effect_Rotate)target;
+            EditorGUI.BeginChangeCheck();
+            DrawDefaultInspector();
+            if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
+        }
+    }
+}

--- a/Editor/RotateEffectEditor.cs.meta
+++ b/Editor/RotateEffectEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 21b90296732640e6a75950feb6f9ce57
+timeCreated: 1749308417

--- a/Editor/ScaleEffectEditor.cs
+++ b/Editor/ScaleEffectEditor.cs
@@ -1,0 +1,17 @@
+using EasyTextEffects.Effects;
+using UnityEditor;
+
+namespace EasyTextEffects.Editor
+{
+    [CustomEditor(typeof(Effect_Scale))]
+    public class ScaleEffectEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var myScript = (Effect_Scale)target;
+            EditorGUI.BeginChangeCheck();
+            DrawDefaultInspector();
+            if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
+        }
+    }
+}

--- a/Editor/ScaleEffectEditor.cs
+++ b/Editor/ScaleEffectEditor.cs
@@ -10,7 +10,9 @@ namespace EasyTextEffects.Editor
         {
             var myScript = (Effect_Scale)target;
             EditorGUI.BeginChangeCheck();
+            serializedObject.Update();
             DrawDefaultInspector();
+            serializedObject.ApplyModifiedProperties();
             if (EditorGUI.EndChangeCheck()) myScript.HandleValueChanged();
         }
     }

--- a/Editor/ScaleEffectEditor.cs.meta
+++ b/Editor/ScaleEffectEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 807ac052e0e24fd28374548200890255
+timeCreated: 1749308556

--- a/Runtime/Effects/Effect_Composite.cs
+++ b/Runtime/Effects/Effect_Composite.cs
@@ -35,9 +35,8 @@ namespace EasyTextEffects.Effects
             ListenForEffectChanges();
         }
 
-        public override void ApplyEffect(TMP_TextInfo _textInfo, int _charIndex,
-                                         int _startVertex = 0,
-                                         int _endVertex = 3)
+        public override void ApplyEffect(TMP_TextInfo _textInfo, int _charIndex, int _startVertex = 0,
+            int _endVertex = 3)
         {
             if (!CheckCanApplyEffect(_charIndex)) return;
 

--- a/Runtime/Effects/Effect_Composite.cs
+++ b/Runtime/Effects/Effect_Composite.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using EasyTextEffects.Editor.MyBoxCopy.Extensions;
@@ -11,8 +10,9 @@ namespace EasyTextEffects.Effects
                      order = 6)]
     public class Effect_Composite : TextEffectInstance
     {
-        [Space(10)] public List<TextEffectInstance> effects = new List<TextEffectInstance>();
         private HashSet<TextEffectInstance> monitoredEffects = new();
+        
+        [Space(10)] public List<TextEffectInstance> effects = new List<TextEffectInstance>();
 
         private void OnEnable()
         {
@@ -91,13 +91,13 @@ namespace EasyTextEffects.Effects
         
         private void ListenForEffectChanges()
         {
-            if (effects == null)
+            if (effects.IsNullOrEmpty())
             {
                 StopListeningForEffectChanges();
                 return;
             }
 
-            var effectsSet = effects.ToHashSet();
+            var effectsSet = effects.Where(effect => effect).ToHashSet();
     
             foreach (var effect in effectsSet.Where(effect => monitoredEffects.Add(effect)))
                 effect.OnValueChanged += HandleValueChanged;

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -146,27 +146,6 @@ namespace EasyTextEffects
             return results;
         }
 
-        public void Refresh()
-        {
-            if (text == null)
-                return;
-            text.ForceMeshUpdate();
-            UpdateStyleInfos();
-        }
-
-        private void Reset()
-        {
-            text = GetComponent<TMP_Text>();
-        }
-
-        private void OnValidate()
-        {
-#if UNITY_EDITOR
-            ListenForEffectChanges();
-            Refresh();
-#endif
-        }
-
         private void ListenForEffectChanges()
         {
             var effects = (tagEffects ?? EmptyEffectEntryList)
@@ -190,6 +169,27 @@ namespace EasyTextEffects
         {
             monitoredEffects.ForEach(x => x.OnValueChanged -= Refresh);
             monitoredEffects.Clear();
+        }
+
+        public void Refresh()
+        {
+            if (text == null)
+                return;
+            text.ForceMeshUpdate();
+            UpdateStyleInfos();
+        }
+
+        private void Reset()
+        {
+            text = GetComponent<TMP_Text>();
+        }
+
+        private void OnValidate()
+        {
+#if UNITY_EDITOR
+            ListenForEffectChanges();
+            Refresh();
+#endif
         }
 
         private void OnEnable()

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -170,11 +170,13 @@ namespace EasyTextEffects
             StopListeningForEffectChanges();
             allEffectInstances.Clear();
 
-            foreach (var entry in tagEffects.Where(entry => entry.effect))
-                allEffectInstances.Add(entry.effect);
+            if (tagEffects != null)
+                foreach (var entry in tagEffects.Where(entry => entry.effect))
+                    allEffectInstances.Add(entry.effect);
 
-            foreach (var entry in globalEffects.Where(entry => entry.effect))
-                allEffectInstances.Add(entry.effect);
+            if (globalEffects != null)
+                foreach (var entry in globalEffects.Where(entry => entry.effect))
+                    allEffectInstances.Add(entry.effect);
             
             allEffectInstances.ForEach(x => x.OnValueChanged += Refresh);
         }

--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -160,8 +160,8 @@ namespace EasyTextEffects
         private void OnValidate()
         {
 #if UNITY_EDITOR
-            Refresh();
             ListenForEffectChanges();
+            Refresh();
 #endif
         }
         
@@ -187,8 +187,8 @@ namespace EasyTextEffects
 #if UNITY_EDITOR
             EditorApplication.update += Update;
 #endif
-            Refresh();
             ListenForEffectChanges();
+            Refresh();
         }
 
         private void OnDisable()

--- a/Runtime/TextEffect_Base.cs
+++ b/Runtime/TextEffect_Base.cs
@@ -1,5 +1,7 @@
 using EasyTextEffects.Editor.EditorDocumentation;
 using TMPro;
+using Unity.Android.Gradle.Manifest;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Serialization;
 using static EasyTextEffects.Editor.EditorDocumentation.FoldBoxAttribute;
@@ -19,8 +21,25 @@ namespace EasyTextEffects
         [HideInInspector] public int startCharIndex;
         [HideInInspector] public int charLength;
 
+        public event System.Action OnValueChanged;
+        public void HandleValueChanged() => OnValueChanged?.Invoke();
+
+        private void OnEnable()
+        {
+            #if UNITY_EDITOR
+            Undo.undoRedoPerformed += HandleValueChanged;
+            #endif
+        }
+
+        private void OnDisable()
+        {
+            #if UNITY_EDITOR
+            Undo.undoRedoPerformed -= HandleValueChanged;
+            #endif
+        }
+
         public abstract void ApplyEffect(TMP_TextInfo _textInfo, int _charIndex, int _startVertex = 0,
-            int _endVertex = 3);
+                                         int _endVertex = 3);
 
         protected Vector3 CharCenter(TMP_CharacterInfo _charInfo, Vector3[] _verts)
         {

--- a/Runtime/TextEffect_Base.cs
+++ b/Runtime/TextEffect_Base.cs
@@ -1,6 +1,5 @@
 using EasyTextEffects.Editor.EditorDocumentation;
 using TMPro;
-using Unity.Android.Gradle.Manifest;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -39,7 +38,7 @@ namespace EasyTextEffects
         }
 
         public abstract void ApplyEffect(TMP_TextInfo _textInfo, int _charIndex, int _startVertex = 0,
-                                         int _endVertex = 3);
+            int _endVertex = 3);
 
         protected Vector3 CharCenter(TMP_CharacterInfo _charInfo, Vector3[] _verts)
         {


### PR DESCRIPTION
Having to press **Refresh** each time I made a change was quite annoying so I implemented a Live Reload feature.
It should be fairly optimized as it utilizes events and performs as few operations as possible.
This works with all the current effects, including Composite and PerVertex, however, I didn't get to test if it works in builds yet(it should tho).
I tried to keep the same style as the rest of the code so feel free to let me know if I missed something.
I'd be happy to make any adjustments you suggest.
Thanks for this amazing tool and keep up the great work!