### PR TITLE
Moved ListenForEffectChanges to Refresh

### DIFF
--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -173,6 +173,8 @@ namespace EasyTextEffects
 
         public void Refresh()
         {
+            ListenForEffectChanges();
+            
             if (text == null)
                 return;
             text.ForceMeshUpdate();
@@ -187,7 +189,6 @@ namespace EasyTextEffects
         private void OnValidate()
         {
 #if UNITY_EDITOR
-            ListenForEffectChanges();
             Refresh();
 #endif
         }
@@ -197,7 +198,6 @@ namespace EasyTextEffects
 #if UNITY_EDITOR
             EditorApplication.update += Update;
 #endif
-            ListenForEffectChanges();
             Refresh();
         }
 


### PR DESCRIPTION
This fixes a bug where it was impossible to get the TextEffect to listen for effect changes if they were added via script.
Simply calling ListenForEffectChanges in the Refresh function instead of separately.
The reason for it being called above the text null check is that we can add effects even if the text is null.