### PR TITLE
Fix Warning "Effect not found" for StartManualEffect and StartManualTagEffect

### DIFF
--- a/Runtime/TextEffect.cs
+++ b/Runtime/TextEffect.cs
@@ -313,7 +313,10 @@ namespace EasyTextEffects
             {
                 effectEntry.StartEffect();
             }
-            Debug.LogWarning($"Effect {_effectName} not found. Available effects: {string.Join(", ", manualEffects_.Select(_entry => _entry.effect.effectTag).ToList())}");
+            else
+            {
+                Debug.LogWarning($"Effect {_effectName} not found. Available effects: {string.Join(", ", manualEffects_.Select(_entry => _entry.effect.effectTag).ToList())}");
+            }
         }
 
         public void StartManualTagEffect(string _effectName)
@@ -323,7 +326,10 @@ namespace EasyTextEffects
             {
                 effectEntry.StartEffect();
             }
-            Debug.LogWarning($"Effect {_effectName} not found. Available effects: {string.Join(", ", manualEffects_.Select(_entry => _entry.effect.effectTag).ToList())}");
+            else
+            {
+                Debug.LogWarning($"Effect {_effectName} not found. Available effects: {string.Join(", ", manualEffects_.Select(_entry => _entry.effect.effectTag).ToList())}");
+            }
         }
 
         public List<TextEffectStatus> QueryEffectStatuses(TextEffectType _effectType,


### PR DESCRIPTION
Fix excess Warning "Effect not found" in StartManualEffect and StartManualTagEffect.
Methods not finished after effect starting, because return statement was removed with return type.